### PR TITLE
Upgrade with pip3 instead of pip

### DIFF
--- a/autoupgrade/package.py
+++ b/autoupgrade/package.py
@@ -12,6 +12,7 @@ from .exceptions import NoVersionsError, PkgNotFoundError
 from subprocess import CalledProcessError
 from .utils import ver_to_tuple
 
+
 class Package(object):
     """
     AutoUpgrade class, holds one package.
@@ -65,7 +66,7 @@ class Package(object):
             force: reinstall all packages even if they are already up-to-date
         Returns True if pip was sucessful
         """
-        pip_args = ['pip', 'install', self.pkg]
+        pip_args = ['pip3', 'install', self.pkg]
 
         found = self._get_current() != (-1)
         if found:

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name="autoupgrade-prima",
-    version="0.5.0",
+    version="0.5.1",
     author="Walter Purcaro",
     author_email="vuolter@gmail.com",
     description="Automatic upgrade of PyPI packages",


### PR DESCRIPTION
 

 Ciao,
durante l'aggiornamento di suite-py mi si è spaccato (anche a usu) perchè provava a usare python2:

> Upgrading suite_py ...
> DEPRECATION: Python 2.7 will reach the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 won't be maintained after that date. A future version of pip will drop support for Python 2.7. More details about Python 2 support in pip, can be found at https://pip.pypa.io/en/latest/development/release-process/#python-2-support
> Requirement already up-to-date: suite_py in /Users/roberto/Documents/Repositories/suite_py (0.13.1)
> Collecting prima-youtrack==0.2.4
>   Using cached https://files.pythonhosted.org/packages/1d/53/bef5a9b80c261fa45454250ee5e9f4dcd52d64c90531ee9e7ffa313072d3/prima-youtrack-0.2.4.tar.gz
>     ERROR: Command errored out with exit status 1:
>      command: /usr/local/opt/python@2/bin/python2.7 -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/private/var/folders/0z/71rkl5px3sz4533bgntgd9n40000gn/T/pip-install-GtNVDp/prima-youtrack/setup.py'"'"'; __file__='"'"'/private/var/folders/0z/71rkl5px3sz4533bgntgd9n40000gn/T/pip-install-GtNVDp/prima-youtrack/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base /private/var/folders/0z/71rkl5px3sz4533bgntgd9n40000gn/T/pip-install-GtNVDp/prima-youtrack/pip-egg-info
>          cwd: /private/var/folders/0z/71rkl5px3sz4533bgntgd9n40000gn/T/pip-install-GtNVDp/prima-youtrack/
>     Complete output (7 lines):
>     Traceback (most recent call last):
>       File "<string>", line 1, in <module>
>       File "/private/var/folders/0z/71rkl5px3sz4533bgntgd9n40000gn/T/pip-install-GtNVDp/prima-youtrack/setup.py", line 5, in <module>
>         from youtrack import config
>       File "youtrack/__init__.py", line 1, in <module>
>         from youtrack.config import __version__
>     ImportError: No module named config
>     ----------------------------------------
> ERROR: Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.
> Errore eseguendo il comando: Command '['pip', 'install', 'suite_py', '--upgrade']' returned non-zero exit status 1.
> 

Ho risolto lanciando il comando: `pip3 install suite_py --upgrade`

Da valutare se la modifica nella PR è corretta a livello logico oppure ho qualcosa configurato male io sul mio pc

Aggiungo che con le release precedenti di suite-py, si è aggiornato senza problemi