### PR TITLE
Find pip3 when running in a virtualenv.

### DIFF
--- a/autoupgrade/__init__.py
+++ b/autoupgrade/__init__.py
@@ -39,7 +39,7 @@ class Package(object):
         """
         restart = False
 
-        pip_args = ["pip3", "install", self.pkg, "--upgrade"]
+        pip_args = [self._find_pip(), "install", self.pkg, "--upgrade"]
 
         if not self.verbose:
             pip_args.append("--quiet")
@@ -99,10 +99,15 @@ class Package(object):
     def _get_installed_version(self):
         try:
             output = subprocess.run(
-                ["pip3", "show", self.pkg], check=True, stdout=subprocess.PIPE
+                [self._find_pip(), "show", self.pkg], check=True, stdout=subprocess.PIPE
             ).stdout.decode("utf-8")
 
             return re.search(self.regex, output).group(1)
         except (CalledProcessError) as e:
             print(f"Errore eseguendo il comando: {e}")
             sys.exit(-1)
+
+    def _find_pip(self):
+        if sys.base_prefix != sys.prefix: # running from venv
+            return sys.prefix+"/bin/pip3"
+        return "pip3"


### PR DESCRIPTION
If autoupgrade is called from a program executed from a virtualenv like this (where the venv is not activated):

$ venv/bin/myprogram

Without this patch, it would try to call the system pip3, it would not find the relevant packages installed, and it would crash (sys.exit(-1), which might not be the best thing to do anyway).

With this patch, it will find the pip3 from the venv, and call it.