### PR TITLE
require setuptools explicitly, and bump version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name="autoupgrade-prima",
-    version="0.6.5",
+    version="0.6.6",
     author="Walter Purcaro",
     author_email="vuolter@gmail.com",
     description="Automatic upgrade of PyPI packages",
@@ -14,7 +14,7 @@ setup(
     include_package_data=True,
     url="https://github.com/primait/autoupgrade",
     download_url="https://github.com/primait/autoupgrade/releases",
-    install_requires=["semver"],
+    install_requires=["semver", "setuptools"],
     obsoletes=["autoupgrade"],
     license="MIT License",
     zip_safe=True,


### PR DESCRIPTION
Not sure why I'm not allowed to open the PR directly on the org repo, but anyway!
setuptools used to be always installed on every python env by default, now it has to be added explicitly. Otherwise suite-py fails with:

```
Traceback (most recent call last):
  File "/home/jaume/bin/suite-py", line 5, in <module>
    from suite_py.cli import main
  File "/home/jaume/prima/venvs/suitepy/lib/python3.12/site-packages/suite_py/cli.py", line 41, in <module>
    from autoupgrade import Package
  File "/home/jaume/prima/venvs/suitepy/lib/python3.12/site-packages/autoupgrade/__init__.py", line 9, in <module>
    import pkg_resources
ModuleNotFoundError: No module named 'pkg_resources'
```

I'm not super familiar with python packaging, but if I understand correctly, this change will fix it.